### PR TITLE
Remove multi topic, and change multi plant a bit

### DIFF
--- a/Core/Models/QueryParameters.cs
+++ b/Core/Models/QueryParameters.cs
@@ -3,19 +3,20 @@
 public class QueryParameters
 {
     //Empty constructor for JSON parsing
-    public QueryParameters() : this(new List<string>(), new List<string>()){}
+    public QueryParameters() : this( new List<string>(), ""){}
 
-    public QueryParameters(string plant, string pcsTopic, bool shouldAddToQueue = false) : this(new List<string> { plant }, new List<string> { pcsTopic }, shouldAddToQueue) { }
-    public QueryParameters(List<string> plants, List<string> pcsTopics, bool shouldAddToQueue = false)
+    public QueryParameters(string plant, string pcsTopic, bool shouldAddToQueue = false) : this(new List<string> { plant },pcsTopic, shouldAddToQueue) { }
+    public QueryParameters(List<string> plants, string topic, bool shouldAddToQueue = false)
     {
         Plants = plants;
-        PcsTopics = pcsTopics;
+        PcsTopic = topic;
         ShouldAddToQueue = shouldAddToQueue;
     }
 
-    public List<string> Plants { get; }
+    public string PcsTopic { get; set; }
 
-    public List<string> PcsTopics { get; }
+    public List<string> Plants { get; }
+    
     
     public bool ShouldAddToQueue { get; set; }
   

--- a/Core/Services/SearchFeederService.cs
+++ b/Core/Services/SearchFeederService.cs
@@ -32,10 +32,10 @@ public class SearchFeederService : ISearchFeederService
         _logger = logger;
         var batchSize = int.Parse(_famFeederOptions.SearchIndexBatchSize ?? "20");
         var itemCount = 0;
+        var topic = queryParameters.PcsTopic;
         foreach (var plant in queryParameters.Plants)
         {
-            foreach (var topic in queryParameters.PcsTopics)
-            {
+           
                 var items = new List<IndexDocument>();
 
                 try
@@ -66,10 +66,10 @@ public class SearchFeederService : ISearchFeederService
 
                 _logger.LogInformation("Finished adding {topic} for plant {plant} to Index", topic, plant);
                 itemCount += items.Count;
-            }
+            
         }
 
-        return $"finished successfully sending {itemCount} documents to Search Index {string.Join(",",queryParameters.Plants)} {string.Join(",",queryParameters.PcsTopics)}";
+        return $"finished successfully sending {itemCount} documents to Search Index {string.Join(",",queryParameters.Plants)} {queryParameters.PcsTopic}";
     }
 
     public Task<List<string>> GetAllPlants() => _plantRepository.GetAllPlants();
@@ -113,9 +113,7 @@ public class SearchFeederService : ISearchFeederService
         // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault
         foreach (var plant in queryParameters.Plants)
         {
-            foreach (var topic in queryParameters.PcsTopics)
-            {
-                switch (topic)
+                switch (queryParameters.PcsTopic)
                 {
                     case PcsTopicConstants.CommPkg:
                         events.AddRange(await _searchItemRepo.GetCommPackages(plant));
@@ -131,9 +129,8 @@ public class SearchFeederService : ISearchFeederService
                         break;
                     default:
                     {
-                        _logger?.LogInformation("{Topic} not included in switch statement",topic);
+                        _logger?.LogInformation("{Topic} not included in switch statement",queryParameters.PcsTopic);
                         break;
-                    }
                 }
             }
         }

--- a/FamFeederFunction/Functions/FamFeeder/TopicHttpTrigger.cs
+++ b/FamFeederFunction/Functions/FamFeeder/TopicHttpTrigger.cs
@@ -49,21 +49,20 @@ public class TopicHttpTrigger
     {
         //We send this as a param to control the flow of the function later
         const bool shouldSendToCompletion = true; 
-        var (topicsString, plants) = await DeserializeTopicAndPlant(req);
-        log.LogInformation("Querying {Plant} for {TopicString}", plants, topicsString);
+        var (topicString, plants) = await DeserializeTopicAndPlant(req);
+        log.LogInformation("Querying {Plant} for {TopicString}", plants, topicString);
 
-        if (topicsString is null || plants is null)
+        if (topicString is null || plants is null)
         {
             return new BadRequestObjectResult("Please provide both plant and topic");
         }
 
-        if (!HasValidTopic(topicsString))
+        if (!HasValidTopic(topicString))
         {
             return new BadRequestObjectResult("Please provide valid topics");
         }
-
-       
-        var param = new QueryParameters(SplitList(plants), topicsString,shouldSendToCompletion);
+        
+        var param = new QueryParameters(SplitList(plants), topicString,shouldSendToCompletion);
         var instanceId = await orchestrationClient.StartNewAsync(nameof(TopicOrchestrator), param);
         return orchestrationClient.CreateCheckStatusResponse(req, instanceId);
     }
@@ -73,11 +72,9 @@ public class TopicHttpTrigger
         return new List<string>(input.Split(",", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
     }
 
-    public static bool HasValidTopic(string topics)
+    public static bool HasValidTopic(string topic)
     {
-        var topicsQuery = SplitList(topics);
-        return topicsQuery.All(s =>
-            TopicHelper.GetAllTopicsAsEnumerable().Contains(s, StringComparer.InvariantCultureIgnoreCase));
+          return  TopicHelper.GetAllTopicsAsEnumerable().Contains(topic, StringComparer.InvariantCultureIgnoreCase);
     }
 
     private static async Task<(string? topicsString, string? plants)> DeserializeTopicAndPlant(HttpRequest req)

--- a/FamFeederTests/TopicHttpTriggerTests.cs
+++ b/FamFeederTests/TopicHttpTriggerTests.cs
@@ -21,10 +21,10 @@ public class TopicHttpTriggerTests
     }
 
     [TestMethod]
-    public void Has_Atleast_One_Valid_Topic()
+    public void HasValidTopics_Fails_IfOneOfTheTopicsAreInvalid()
     {
         var topics = "NOT_VALID,Action";
-        Assert.IsTrue(TopicHttpTrigger.HasValidTopic(topics));
+        Assert.IsFalse(TopicHttpTrigger.HasValidTopic(topics));
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixed validation All plants from input must be Valid. This means multiPlantArguments needs to be called alone to work.

removed unused loops inside FeederFunction, as its always called with 1 Plant.
Removed multiTopic. We can re add, but it needs to function same way as multiplant.
fixed multiple plant inputs to use the MultiPlant orchistrator (Fan-in Fan-out)

